### PR TITLE
Update Free Code Camp to freeCodeCamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Oh, and I've still got a lot of bookmarks to go through, so I'll be updating and
 ### Free Full-Stack Programs, Classes, and Tutorials
 * Programs
   * [The Odin Project](http://www.theodinproject.com/)
-  * [Free Code Camp](https://www.freecodecamp.com/)
+  * [freeCodeCamp](https://www.freecodecamp.com/)
   * [The Essential Web Developer Course](http://upskillcourses.com/p/essential-web-developer-course)
 * Classes
   * [SANITIZED list of 530+ free online programming/CS courses (MOOCs) with feedback(i.e. exams/homeworks/assignments) that you can start this month (December 2016)](https://www.reddit.com/r/learnprogramming/comments/5gr8nw/heres_a_sanitized_list_of_530_free_online/) - *Needs Updating*


### PR DESCRIPTION
This change fixes the correct style for the resource name "freeCodeCamp", we have moved to the new style recently.