### PR TITLE
Add free eBook: The Road to learn React

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ I've still got a lot of bookmarks to go through, so I'll be updating and adding 
   * [Working with React](https://medium.com/@prodia/working-with-react-js-3e21a2ff5443#.ensczdgi0)
   * [Beginners guide to React Router (Medium)](https://medium.com/@dabit3/beginner-s-guide-to-react-router-53094349669#.4lul6fhvy)
   * [Angular JS vs React JS (Medium)](https://medium.com/@paramsingh_66174/angularjs-vs-reactjs-e651a194dfcb#.bbx4qapwu)
+  * [The Road to learn React - Build a Hacker News App along the way](https://leanpub.com/the-road-to-learn-react)
 
 ---
 ### Full Stack Tutorials


### PR DESCRIPTION
Okay, my second and last attempt to add the book :) The book is perceived as an open source book to learn React. People like and share it in the community. I would love to see it in the list of React resources. 

Even though people can pay what they want to support events like this: https://www.robinwieruch.de/giving-back-by-learning-react/